### PR TITLE
Fix footer email link with click-to-copy functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -936,13 +936,32 @@
         <div class="footer-location">Pianoro (BO), Italia</div>
         <div class="footer-cta">¿LISTO PARA ELEVAR TU EQUIPO? HABLEMOS</div>
         <div class="footer-email">
-            <a href="mailto:pablo@pablosuarez.me">EMAIL</a>
+            <a href="#" id="emailLink" onclick="copyEmail(event)">pablo@pablosuarez.me</a>
             <a href="https://www.instagram.com/pablosuarezsenior">INSTAGRAM</a>
             <a href="https://pablosuarez.me/contact.html">Descarga mi CV</a>
         </div>
     </footer>
 
     <script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script><script>
+        // Copy email to clipboard
+        function copyEmail(event) {
+            event.preventDefault();
+            const email = 'pablo@pablosuarez.me';
+            navigator.clipboard.writeText(email).then(() => {
+                const link = event.target;
+                const originalText = link.textContent;
+                link.textContent = '✓ Copiado!';
+                link.style.color = 'var(--gold)';
+                setTimeout(() => {
+                    link.textContent = originalText;
+                    link.style.color = '';
+                }, 2000);
+            }).catch(() => {
+                // Fallback: open mailto if copy fails
+                window.location.href = 'mailto:' + email;
+            });
+        }
+
         // Intersection Observer for scroll animations
         const observerOptions = {
             threshold: 0.1,


### PR DESCRIPTION
- Replace 'EMAIL' text with actual email address for better visibility
- Add JavaScript click-to-copy feature that works without email client
- Show '✓ Copiado!' visual feedback when email is copied
- Fallback to mailto link if clipboard API is not available